### PR TITLE
Added secret token update from frontend. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,7 @@ A serverless LeetCode practice tracker built with Next.js and deployed on Vercel
    
 4. Create a Redis cache using Vercel. Vercel Marketplace provides easy integration with Upstash Redis for Nextjs. Store the Redis Secrets in your `.env` file.
 
-5. Add the update_token in the browser's local storage. The SECRET_TOKEN must match exactly with the one in your `.env` file. Open your browser console and run:
-     ```javascript
-     localStorage.setItem('update_token', SECRET_TOKEN)
-     ```
-6. Deploy the project on Vercel. Once you receive the project URL from Vercel, update the baseurl in `api/cron/daily-update/route.ts` with the new URL, then redeploy the project on Vercel.
+5. Deploy the project on Vercel. Once you receive the project URL from Vercel, update the baseurl in `api/cron/daily-update/route.ts` with the new URL, then redeploy the project on Vercel.
 
 ## EmailJS Template
 Use the following variables in your EmailJS template:

--- a/app/components/todayquestion-components/questioncard.tsx
+++ b/app/components/todayquestion-components/questioncard.tsx
@@ -34,7 +34,7 @@ export const QuestionCard = ({ questionNumber, questionId, questionUrl, question
         try {
             let token = localStorage.getItem('update_token');
             if (!token) {
-                token = window.prompt('Please enter your update token:');
+                token = window.prompt('Please enter your secret token:');
                 if (token) {
                     localStorage.setItem('update_token', token);
                 } else {

--- a/app/components/todayquestion-components/questioncard.tsx
+++ b/app/components/todayquestion-components/questioncard.tsx
@@ -32,7 +32,15 @@ export const QuestionCard = ({ questionNumber, questionId, questionUrl, question
         setUpdateStatus(null);
 
         try {
-            const token = localStorage.getItem('update_token');
+            let token = localStorage.getItem('update_token');
+            if (!token) {
+                token = window.prompt('Please enter your update token:');
+                if (token) {
+                    localStorage.setItem('update_token', token);
+                } else {
+                    return;
+                }
+            }
 
             const response = await fetch(`/api/commit-question?token=${token}&id1=${questionId}`, {
                 method: 'GET',

--- a/app/components/todayquestion-components/todayquestion.tsx
+++ b/app/components/todayquestion-components/todayquestion.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback } from 'react';
 import { CheckCircleIcon, XCircleIcon, ExternalLinkIcon, CalendarIcon } from '@/app/components/todayquestion-components/icons';
-import {TodayQuestion, ApiResponse} from "@/app/components/todayquestion-components/todayquuestion-interface";
+import { TodayQuestion, ApiResponse } from "@/app/components/todayquestion-components/todayquuestion-interface";
 import { QuestionCard } from '@/app/components/todayquestion-components/questioncard';
 
 export default function TodaysQuestions() {
@@ -52,6 +52,15 @@ export default function TodaysQuestions() {
         await fetchTodaysQuestions();
     }, [fetchTodaysQuestions]);
 
+    // Handle update_token update
+    const handleUpdateToken = () => {
+        const newToken = prompt("Enter the new secret_token (This will only update the token present in this browser) (Use this option only if you previously entered the wrong token) :");
+        if (newToken) {
+            localStorage.setItem("update_token", newToken);
+            alert("update_token updated successfully!");
+        }
+    };
+
     if (loading) {
         return (
             <div className="bg-white rounded-lg shadow-md p-6">
@@ -100,9 +109,18 @@ export default function TodaysQuestions() {
             <div className="bg-white rounded-lg shadow-md p-6">
                 <div className="flex items-center justify-between mb-4">
                     <h2 className="text-2xl font-semibold text-gray-800">Today's Questions</h2>
-                    <div className="flex items-center text-gray-600">
-                        <CalendarIcon className="w-5 h-5 mr-2" />
-                        <span className="text-sm">{new Date().toLocaleDateString()}</span>
+                    <div className="flex items-center space-x-3">
+                        <div className="flex items-center text-gray-600">
+                            <CalendarIcon className="w-5 h-5 mr-2" />
+                            <span className="text-sm">{new Date().toLocaleDateString()}</span>
+                        </div>
+                        {/* Update Token Button */}
+                        <button
+                            onClick={handleUpdateToken}
+                            className="px-3 py-1 text-sm bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition"
+                        >
+                            Update Token
+                        </button>
                     </div>
                 </div>
 


### PR DESCRIPTION
This pull request improves the user experience around managing the `update_token` used for authentication in the browser. It removes the manual step from the setup instructions and adds in-app functionality for entering and updating the token directly from the UI, making the process more intuitive and user-friendly.

**Improvements to token management:**

* Removed the step from `README.md` that required users to manually add `update_token` to local storage via the browser console, simplifying the setup process.
* Updated `questioncard.tsx` so that if `update_token` is missing from local storage, users are prompted to enter it, which is then saved for future use.
* Added a handler in `todayquestion.tsx` to allow users to update their `update_token` at any time via a prompt, storing the new value in local storage.
* Added an "Update Token" button to the UI in `todayquestion.tsx`, making it easy for users to trigger the token update prompt directly from the Today's Questions page.